### PR TITLE
fix(friends-since): avoid crash from missing intl module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Hey,

This PR fixes a bug where the plugin crashes on load due to the following error:
```javascript
TypeError: Cannot destructure property 'intl' of 'BdApi.Webpack.getModule(...)' as it is undefined.
```
**Changes:**
- Replaced the direct destructuring of intl with a safe fallback using navigator.language or "en-US".

**Fixes:**
- Fixes #40 